### PR TITLE
fix time header issue on alpine

### DIFF
--- a/c_src/nif.c
+++ b/c_src/nif.c
@@ -33,11 +33,11 @@
 #include <stdlib.h>
 #include <fcntl.h>
 #include <errno.h>
-#include <time.h>
-#if defined(OS_LINUX)
-#include <linux/time.h>
+#if !defined(OS_LINUX)
+#  include <time.h>
+#else
+#  include <linux/time.h>
 #endif
-
 #include <math.h>
 
 #include "queue.h"


### PR DESCRIPTION
These changes allow the library to compile on the minimal Alpine Linux distribution, which is a popular base image for docker erlang deployments. The following dockerfile reproduces the problem in the existing code and executes correctly with these changes.

```
FROM bitwalker/alpine-erlang:20.1

RUN apk --no-cache --update upgrade && \
    apk --no-cache add busybox make g++

ADD . .
ADD https://s3.amazonaws.com/rebar3/rebar3 /build/
RUN chmod a+x /build/rebar3

RUN apk --no-cache add linux-headers

CMD /build/rebar3 compile
```

This image can be built/run with the following command:
```
docker build -t e2qc . && docker run -it --rm e2qc
```

I verified that these changes also work under ubuntu.
