### PR TITLE
remove erl_interface references

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -6,8 +6,6 @@ BASEDIR := $(abspath $(CURDIR)/..)
 PROJECT = e2qc_nif
 
 ERTS_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s/erts-~s/include/\", [code:root_dir(), erlang:system_info(version)]).")
-ERL_INTERFACE_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s\", [code:lib_dir(erl_interface, include)]).")
-ERL_INTERFACE_LIB_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s\", [code:lib_dir(erl_interface, lib)]).")
 
 C_SRC_DIR = $(CURDIR)
 C_SRC_OUTPUT ?= $(CURDIR)/../priv/$(PROJECT).so
@@ -66,10 +64,10 @@ else ifeq ($(UNAME_SYS), Linux)
 	CXXFLAGS ?= -O3 -std=c++11 -finline-functions -Wall -DOS_LINUX
 endif
 
-CFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR)
-CXXFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR)
+CFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR)
+CXXFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR)
 
-LDLIBS += -L $(ERL_INTERFACE_LIB_DIR) -lerl_interface -lei
+LDLIBS +=
 LDFLAGS += -shared
 
 # Verbosity.


### PR DESCRIPTION
Hello project-fifo! We have used your e2qc library for some time in our Elixir application and appreciate your work here.

The erl_interface library has been deprecated for a while in Erlang and was removed in OTP 23, so these changes remove references to the deprecated library from the project so that it can compile.

Once this PR has been merged, please publish an update to hex.pm, so that e2qc can be used in OTP 23/Elixir 1.11. Please let me know if you have any questions or if I have made any mistakes here, and thanks again!
